### PR TITLE
Added tide for istio-releases/pipeline

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -206,6 +206,14 @@ branch-protection:
 tide:
   queries:
   - repos:
+    - istio-releases/pipeline
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/hold
+    - do-not-merge/work-in-progress
+    - needs-ok-to-test
+    - needs-rebase
+  - repos:
     - istio/api
     - istio/test-infra
     - istio/istio


### PR DESCRIPTION
Someone deleted istio-releases/pipeline from the tide config. I cannot find the PR who did it. Adding it back.